### PR TITLE
db restore command

### DIFF
--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -51,7 +51,7 @@ abra app wordpress_blog_example_com restore blog_example_com_app.tar.gz
 and/or the database:
 
 ```
-abra app wordpress_blog_example_com restore blog_example_com_db.sql.gz
+abra app wordpress_blog_example_com restore db blog_example_com_db.sql.gz
 ```
 
 (there isn't yet a command to restore files and database data at the same time)


### PR DESCRIPTION
the command mentioned previously causes "ERROR: 'wordpress' doesn't know how to restore backups." while this one seems to run